### PR TITLE
feat(user): 회원 등록 유스케이스 테스트 추가 및 PasswordEncoder 변경

### DIFF
--- a/common/security/src/main/kotlin/com/nextmall/common/security/SecurityConfig.kt
+++ b/common/security/src/main/kotlin/com/nextmall/common/security/SecurityConfig.kt
@@ -3,9 +3,10 @@ package com.nextmall.common.security
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 
 @Configuration
 class SecurityConfig {
     @Bean
-    fun passwordEncoder(): BCryptPasswordEncoder = BCryptPasswordEncoder()
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 }

--- a/modules/user/build.gradle.kts
+++ b/modules/user/build.gradle.kts
@@ -31,4 +31,10 @@ dependencies {
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.boot.starter.validation)
     implementation(libs.spring.security.crypto)
+
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.framework.engine)
+    testImplementation(libs.mockk)
 }

--- a/modules/user/src/main/kotlin/com/nextmall/user/application/usecase/RegisterUserUseCase.kt
+++ b/modules/user/src/main/kotlin/com/nextmall/user/application/usecase/RegisterUserUseCase.kt
@@ -4,14 +4,14 @@ import com.nextmall.user.domain.exception.DuplicateEmailException
 import com.nextmall.user.domain.model.User
 import com.nextmall.user.domain.repository.UserRepository
 import com.nextmall.user.presentation.dto.RegisterUserResponse
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class RegisterUserUseCase(
     private val userRepository: UserRepository,
-    private val passwordEncoder: BCryptPasswordEncoder,
+    private val passwordEncoder: PasswordEncoder,
 ) {
     @Transactional
     fun register(

--- a/modules/user/src/test/kotlin/com/nextmall/user/application/usecase/RegisterUserUseCaseTest.kt
+++ b/modules/user/src/test/kotlin/com/nextmall/user/application/usecase/RegisterUserUseCaseTest.kt
@@ -1,0 +1,25 @@
+package com.nextmall.user.application.usecase
+
+import com.nextmall.user.domain.exception.DuplicateEmailException
+import com.nextmall.user.domain.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class RegisterUserUseCaseTest :
+    FunSpec({
+
+        val userRepository = mockk<UserRepository>()
+        val passwordEncoder = mockk<PasswordEncoder>()
+        val useCase = RegisterUserUseCase(userRepository, passwordEncoder)
+
+        test("중복 이메일이면 DuplicateEmailException 발생") {
+            every { userRepository.existsByEmail("a@b.com") } returns true
+
+            shouldThrow<DuplicateEmailException> {
+                useCase.register("a@b.com", "pw", "nick")
+            }
+        }
+    })


### PR DESCRIPTION
## 🧾 Summary of Changes
- RegisterUserUseCaseTest 추가로 회원 등록 테스트 커버리지 확보
- `BCryptPasswordEncoder`를 인터페이스 `PasswordEncoder`로 변경하여 유연성 확보
- 테스트를 위한 Kotest 및 Mockk 의존성 추가

---

## 🔗 Related Issue
[T7] 회원가입 API 구현 #2 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 사용자 등록 중 중복 이메일 검증에 대한 단위 테스트 추가

* **기타**
  * 테스트용 의존성 추가로 테스트 환경 강화
  * 암호화 처리 컴포넌트의 타입을 구체 구현에서 인터페이스로 변경하여 유연성 및 유지보수성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->