### PR TITLE
feat(auth,common): Redis 기반 로그인 시도 제한 도입 및 인증 구조 개선

### DIFF
--- a/common/data/src/main/kotlin/com/nextmall/common/data/jpa/BaseEntity.kt
+++ b/common/data/src/main/kotlin/com/nextmall/common/data/jpa/BaseEntity.kt
@@ -2,23 +2,15 @@ package com.nextmall.common.data.jpa
 
 import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
-/**
- * Base class for all JPA entities.
- * Provides ID and auditing fields (createdAt, updatedAt).
- */
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity {
-    @Id
-    var id: Long? = null
-
     @CreatedDate
     @Column(nullable = false, updatable = false)
     var createdAt: LocalDateTime? = null

--- a/common/identifier/src/main/kotlin/com/nextmall/common/identifier/config/IdentifierConfig.kt
+++ b/common/identifier/src/main/kotlin/com/nextmall/common/identifier/config/IdentifierConfig.kt
@@ -1,5 +1,8 @@
-package com.nextmall.common.identifier
+package com.nextmall.common.identifier.config
 
+import com.nextmall.common.identifier.IdGenerator
+import com.nextmall.common.identifier.IdentifierProperties
+import com.nextmall.common.identifier.SnowflakeIdGenerator
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/common/identifier/src/test/kotlin/com/nextmall/common/identifier/IdentifierConfigTest.kt
+++ b/common/identifier/src/test/kotlin/com/nextmall/common/identifier/IdentifierConfigTest.kt
@@ -1,5 +1,6 @@
 package com.nextmall.common.identifier
 
+import com.nextmall.common.identifier.config.IdentifierConfig
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldNotBe
 

--- a/common/redis/build.gradle.kts
+++ b/common/redis/build.gradle.kts
@@ -14,4 +14,8 @@ dependencies {
     implementation(platform(libs.spring.boot.dependencies))
     implementation(libs.kotlin.reflect)
     implementation(libs.spring.boot.starter.data.redis)
+
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.mockk)
 }

--- a/common/redis/build.gradle.kts
+++ b/common/redis/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.dependency.management)
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+dependencies {
+    implementation(platform(libs.spring.boot.dependencies))
+    implementation(libs.kotlin.reflect)
+    implementation(libs.spring.boot.starter.data.redis)
+}

--- a/common/redis/src/main/kotlin/com/nextmall/common/redis/RedisConfig.kt
+++ b/common/redis/src/main/kotlin/com/nextmall/common/redis/RedisConfig.kt
@@ -1,0 +1,23 @@
+package com.nextmall.common.redis
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig {
+    @Bean
+    fun stringRedisTemplate(
+        connectionFactory: RedisConnectionFactory,
+    ): StringRedisTemplate {
+        val template = StringRedisTemplate()
+        template.connectionFactory = connectionFactory
+
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = StringRedisSerializer()
+
+        return template
+    }
+}

--- a/common/redis/src/main/kotlin/com/nextmall/common/redis/RedisOperator.kt
+++ b/common/redis/src/main/kotlin/com/nextmall/common/redis/RedisOperator.kt
@@ -1,0 +1,27 @@
+package com.nextmall.common.redis
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RedisOperator(
+    private val template: StringRedisTemplate,
+) {
+    fun increment(key: String, ttl: Duration? = null): Long {
+        val count = template.opsForValue().increment(key) ?: 0L
+
+        if (ttl != null && template.getExpire(key) == -1L) {
+            template.expire(key, ttl)
+        }
+
+        return count
+    }
+
+    fun getValue(key: String): String? =
+        template.opsForValue().get(key) // NOSONAR
+
+    fun delete(key: String) {
+        template.delete(key)
+    }
+}

--- a/common/redis/src/main/kotlin/com/nextmall/common/redis/RedisOperator.kt
+++ b/common/redis/src/main/kotlin/com/nextmall/common/redis/RedisOperator.kt
@@ -21,7 +21,6 @@ class RedisOperator(
     fun getValue(key: String): String? =
         template.opsForValue().get(key) // NOSONAR
 
-    fun delete(key: String) {
+    fun delete(key: String): Boolean =
         template.delete(key)
-    }
 }

--- a/common/redis/src/main/kotlin/com/nextmall/common/redis/config/RedisConfig.kt
+++ b/common/redis/src/main/kotlin/com/nextmall/common/redis/config/RedisConfig.kt
@@ -1,4 +1,4 @@
-package com.nextmall.common.redis
+package com.nextmall.common.redis.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/common/redis/src/test/kotlin/com/nextmall/common/redis/RedisOperatorTest.kt
+++ b/common/redis/src/test/kotlin/com/nextmall/common/redis/RedisOperatorTest.kt
@@ -1,0 +1,94 @@
+package com.nextmall.common.redis
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Duration
+
+class RedisOperatorTest :
+    FunSpec({
+
+        val template = mockk<StringRedisTemplate>()
+        val valueOps = mockk<ValueOperations<String, String>>()
+
+        val operator = RedisOperator(template)
+
+        beforeTest {
+            every { template.opsForValue() } returns valueOps
+        }
+
+        test("increment는 opsForValue.increment 호출 후 TTL이 없으면 expire를 설정한다") {
+            // given
+            every { valueOps.increment("test-key1") } returns 5L
+            every { template.getExpire("test-key1") } returns -1L
+            every { template.expire("test-key1", Duration.ofMinutes(3)) } returns true
+
+            // when
+            val result = operator.increment("test-key1", Duration.ofMinutes(3))
+
+            // then
+            result shouldBe 5L
+
+            verifyOrder {
+                valueOps.increment("test-key1")
+                template.getExpire("test-key1")
+                template.expire("test-key1", Duration.ofMinutes(3))
+            }
+        }
+
+        test("getValue는 Redis의 값을 그대로 반환한다") {
+            // given
+            every { valueOps.get("hello") } returns "world"
+
+            // when
+            val result = operator.getValue("hello")
+
+            // then
+            result shouldBe "world"
+
+            verify(exactly = 1) {
+                valueOps.get("hello")
+            }
+        }
+
+        test("delete는 template.delete 호출한다") {
+            // given
+            every { template.delete("aaa") } returns true
+
+            // when
+            val result = operator.delete("aaa")
+
+            // then
+            result shouldBe true
+
+            verify(exactly = 1) {
+                template.delete("aaa")
+            }
+        }
+
+        test("increment는 TTL이 있어도 기존 TTL이 설정되어 있으면 expire를 호출하지 않는다") {
+            // given
+            every { valueOps.increment("test-key2") } returns 10L
+
+            // TTL이 이미 설정된 경우 (예: 120초 남음)
+            every { template.getExpire("test-key2") } returns 120L
+
+            // expire는 호출되지 않아야 한다
+            every { template.expire("test-key2", any()) } returns true
+
+            // when
+            val result = operator.increment("test-key2", Duration.ofMinutes(3))
+
+            // then
+            result shouldBe 10L
+
+            verify(exactly = 1) { valueOps.increment("test-key2") }
+            verify(exactly = 1) { template.getExpire("test-key2") }
+            verify(exactly = 0) { template.expire("test-key2", any()) }
+        }
+    })

--- a/common/test-support/src/main/kotlin/com/nextmall/common/testsupport/TestJpaConfiguration.kt
+++ b/common/test-support/src/main/kotlin/com/nextmall/common/testsupport/TestJpaConfiguration.kt
@@ -1,6 +1,6 @@
 package com.nextmall.common.testsupport
 
-import com.nextmall.common.identifier.IdentifierConfig
+import com.nextmall.common.identifier.config.IdentifierConfig
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ spring-boot = { module = "org.springframework.boot:spring-boot" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+spring-boot-starter-data-redis = { module = "org.springframework.boot:spring-boot-starter-data-redis" }
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
 spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }

--- a/modules/auth/build.gradle.kts
+++ b/modules/auth/build.gradle.kts
@@ -14,6 +14,7 @@ java {
 dependencies {
     implementation(project(":common:security"))
     implementation(project(":common:data"))
+    implementation(project(":common:redis"))
     implementation(project(":modules:user"))
 
     implementation(libs.kotlin.reflect)

--- a/modules/auth/src/main/kotlin/com/nextmall/auth/application/usecase/LoginUseCase.kt
+++ b/modules/auth/src/main/kotlin/com/nextmall/auth/application/usecase/LoginUseCase.kt
@@ -1,6 +1,9 @@
 package com.nextmall.auth.application.usecase
 
+import com.nextmall.auth.domain.exception.InvalidLoginException
+import com.nextmall.auth.domain.exception.TooManyLoginAttemptsException
 import com.nextmall.auth.domain.jwt.TokenProvider
+import com.nextmall.auth.infrastructure.redis.RateLimitRepository
 import com.nextmall.auth.presentation.dto.TokenResponse
 import com.nextmall.user.domain.repository.UserRepository
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -11,19 +14,32 @@ class LoginUseCase(
     private val userRepository: UserRepository,
     private val passwordEncoder: PasswordEncoder,
     private val tokenProvider: TokenProvider,
+    private val rateLimitRepository: RateLimitRepository,
 ) {
     fun login(email: String, password: String): TokenResponse {
-        val user =
-            userRepository.findByEmail(email)
-                ?: throw IllegalArgumentException("Invalid email or password")
-
-        require(passwordEncoder.matches(password, user.password)) {
-            "Invalid email or password"
+        val failCount = rateLimitRepository.getFailCount(email)
+        if (failCount >= 5) {
+            throw TooManyLoginAttemptsException()
         }
 
-        val accessToken = tokenProvider.generateAccessToken(user.id.toString())
-        val refreshToken = tokenProvider.generateRefreshToken(user.id.toString())
+        val user =
+            userRepository.findByEmail(email)
+                ?: run {
+                    rateLimitRepository.increaseFailCount(email)
+                    throw InvalidLoginException()
+                }
 
-        return TokenResponse(accessToken, refreshToken)
+        if (!passwordEncoder.matches(password, user.password)) {
+            rateLimitRepository.increaseFailCount(email)
+            throw InvalidLoginException()
+        }
+
+        rateLimitRepository.resetFailCount(email)
+
+        val userId = user.id.toString()
+        return TokenResponse(
+            accessToken = tokenProvider.generateAccessToken(userId),
+            refreshToken = tokenProvider.generateRefreshToken(userId),
+        )
     }
 }

--- a/modules/auth/src/main/kotlin/com/nextmall/auth/domain/exception/InvalidLoginException.kt
+++ b/modules/auth/src/main/kotlin/com/nextmall/auth/domain/exception/InvalidLoginException.kt
@@ -1,0 +1,8 @@
+package com.nextmall.auth.domain.exception
+
+/**
+ * Thrown when a login attempt fails due to invalid credentials.
+ */
+class InvalidLoginException(
+    message: String = "Invalid email or password.",
+) : RuntimeException(message)

--- a/modules/auth/src/main/kotlin/com/nextmall/auth/domain/exception/TooManyLoginAttemptsException.kt
+++ b/modules/auth/src/main/kotlin/com/nextmall/auth/domain/exception/TooManyLoginAttemptsException.kt
@@ -1,0 +1,8 @@
+package com.nextmall.auth.domain.exception
+
+/**
+ * Thrown when a user exceeds the allowed number of login attempts.
+ */
+class TooManyLoginAttemptsException(
+    message: String = "Too many failed login attempts. Please try again later.",
+) : RuntimeException(message)

--- a/modules/auth/src/main/kotlin/com/nextmall/auth/infrastructure/redis/RateLimitRepository.kt
+++ b/modules/auth/src/main/kotlin/com/nextmall/auth/infrastructure/redis/RateLimitRepository.kt
@@ -1,0 +1,28 @@
+package com.nextmall.auth.infrastructure.redis
+
+import com.nextmall.common.redis.RedisOperator
+import org.springframework.stereotype.Repository
+import java.time.Duration
+
+@Repository
+class RateLimitRepository(
+    private val redisOperator: RedisOperator,
+) {
+    fun increaseFailCount(key: String): Long =
+        redisOperator.increment(
+            key = PREFIX + key,
+            ttl = BLOCK_TTL,
+        )
+
+    fun getFailCount(key: String): Long =
+        redisOperator.getValue(PREFIX + key)?.toLong() ?: 0L
+
+    fun resetFailCount(key: String) {
+        redisOperator.delete(PREFIX + key)
+    }
+
+    companion object {
+        private const val PREFIX = "auth:login:attempts:"
+        private val BLOCK_TTL = Duration.ofMinutes(5)
+    }
+}

--- a/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LoginUseCaseTest.kt
+++ b/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LoginUseCaseTest.kt
@@ -1,13 +1,19 @@
 package com.nextmall.auth.application.usecase
 
+import com.nextmall.auth.domain.exception.InvalidLoginException
+import com.nextmall.auth.domain.exception.TooManyLoginAttemptsException
 import com.nextmall.auth.domain.jwt.TokenProvider
+import com.nextmall.auth.infrastructure.redis.RateLimitRepository
 import com.nextmall.user.domain.model.User
 import com.nextmall.user.domain.repository.UserRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
 
 class LoginUseCaseTest :
@@ -16,15 +22,29 @@ class LoginUseCaseTest :
         val userRepository = mockk<UserRepository>()
         val passwordEncoder = mockk<PasswordEncoder>()
         val tokenProvider = mockk<TokenProvider>()
-        val loginUseCase = LoginUseCase(userRepository, passwordEncoder, tokenProvider)
+        val rateLimitRepository = mockk<RateLimitRepository>()
+
+        lateinit var loginUseCase: LoginUseCase
+
+        beforeTest {
+            loginUseCase =
+                LoginUseCase(
+                    userRepository = userRepository,
+                    passwordEncoder = passwordEncoder,
+                    tokenProvider = tokenProvider,
+                    rateLimitRepository = rateLimitRepository,
+                )
+        }
 
         test("정상 로그인 시 토큰 두 개가 발급된다") {
             // given
-            val user = User(email = "test@a.com", password = "encoded", nickname = "tester")
+            val user = User(id = 1L, email = "test@a.com", password = "encoded", nickname = "tester")
             every { userRepository.findByEmail("test@a.com") } returns user
             every { passwordEncoder.matches("plain", "encoded") } returns true
             every { tokenProvider.generateAccessToken(any()) } returns "access"
             every { tokenProvider.generateRefreshToken(any()) } returns "refresh"
+            every { rateLimitRepository.resetFailCount(any()) } just Runs
+            every { rateLimitRepository.getFailCount(any()) } returns 0
 
             // when
             val result = loginUseCase.login("test@a.com", "plain")
@@ -32,23 +52,51 @@ class LoginUseCaseTest :
             // then
             result.accessToken shouldBe "access"
             result.refreshToken shouldBe "refresh"
+
+            verify(exactly = 1) { rateLimitRepository.resetFailCount("test@a.com") }
         }
 
         test("비밀번호가 일치하지 않으면 예외 발생") {
-            val user = User(email = "test@a.com", password = "encoded", nickname = "tester")
-            every { userRepository.findByEmail("test@a.com") } returns user
+            val user = User(id = 2L, email = "test2@a.com", password = "encoded", nickname = "tester")
+            every { userRepository.findByEmail("test2@a.com") } returns user
             every { passwordEncoder.matches(any(), any()) } returns false
+            every { rateLimitRepository.getFailCount(any()) } returns 0
+            every { rateLimitRepository.increaseFailCount(any()) } returns 0
 
-            shouldThrow<IllegalArgumentException> {
-                loginUseCase.login("test@a.com", "wrong")
+            shouldThrow<InvalidLoginException> {
+                loginUseCase.login("test2@a.com", "wrong")
             }
         }
 
         test("존재하지 않는 이메일이면 예외가 발생한다") {
             every { userRepository.findByEmail("none@test.com") } returns null
+            every { rateLimitRepository.getFailCount(any()) } returns 0
+            every { rateLimitRepository.increaseFailCount(any()) } returns 0
 
-            shouldThrow<IllegalArgumentException> {
+            shouldThrow<InvalidLoginException> {
                 loginUseCase.login("none@test.com", "password")
             }
+        }
+
+        test("로그인 실패 횟수가 5 이상이면 TooManyLoginAttemptsException 발생") {
+            every { rateLimitRepository.getFailCount("test4@a.com") } returns 5
+
+            shouldThrow<TooManyLoginAttemptsException> {
+                loginUseCase.login("test4@a.com", "pw")
+            }
+        }
+
+        test("비밀번호가 틀리면 실패 횟수가 증가한다") {
+            val user = User(id = 5L, email = "test5@a.com", password = "encoded", nickname = "nick")
+            every { userRepository.findByEmail("test5@a.com") } returns user
+            every { passwordEncoder.matches(any(), any()) } returns false
+            every { rateLimitRepository.getFailCount("test5@a.com") } returns 0
+            every { rateLimitRepository.increaseFailCount("test5@a.com") } returns 1
+
+            shouldThrow<InvalidLoginException> {
+                loginUseCase.login("test5@a.com", "pw")
+            }
+
+            verify(exactly = 1) { rateLimitRepository.increaseFailCount("test5@a.com") }
         }
     })

--- a/modules/auth/src/test/kotlin/com/nextmall/auth/infrastructure/redis/RateLimitRepositoryTest.kt
+++ b/modules/auth/src/test/kotlin/com/nextmall/auth/infrastructure/redis/RateLimitRepositoryTest.kt
@@ -1,0 +1,62 @@
+package com.nextmall.auth.infrastructure.redis
+
+import com.nextmall.common.redis.RedisOperator
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Duration
+
+class RateLimitRepositoryTest :
+    FunSpec({
+
+        val redisOperator = mockk<RedisOperator>()
+        val repository = RateLimitRepository(redisOperator)
+
+        test("increaseFailCount는 RedisOperator.increment 결과값을 반환한다") {
+            every { redisOperator.increment(any(), any()) } returns 3L
+
+            val count = repository.increaseFailCount("test@a.com")
+
+            count shouldBe 3L
+            verify(exactly = 1) {
+                redisOperator.increment(
+                    key = "auth:login:attempts:test@a.com",
+                    ttl = Duration.ofMinutes(5),
+                )
+            }
+        }
+
+        test("getFailCount는 RedisOperator.getValue 값을 Long으로 변환하여 반환한다") {
+            every { redisOperator.getValue(any()) } returns "10"
+
+            val count = repository.getFailCount("test@a.com")
+
+            count shouldBe 10L
+            verify(exactly = 1) {
+                redisOperator.getValue("auth:login:attempts:test@a.com")
+            }
+        }
+
+        test("getFailCount는 null이면 0을 반환한다") {
+            every { redisOperator.getValue(any()) } returns null
+
+            val count = repository.getFailCount("no@value.com")
+
+            count shouldBe 0L
+            verify(exactly = 1) {
+                redisOperator.getValue("auth:login:attempts:no@value.com")
+            }
+        }
+
+        test("resetFailCount는 RedisOperator.delete를 호출한다") {
+            every { redisOperator.delete(any()) } returns true
+
+            repository.resetFailCount("test@a.com")
+
+            verify(exactly = 1) {
+                redisOperator.delete("auth:login:attempts:test@a.com")
+            }
+        }
+    })

--- a/modules/user/src/main/kotlin/com/nextmall/user/application/usecase/RegisterUserUseCase.kt
+++ b/modules/user/src/main/kotlin/com/nextmall/user/application/usecase/RegisterUserUseCase.kt
@@ -27,10 +27,11 @@ class RegisterUserUseCase(
 
         val user =
             User(
+                id = idGenerator.generate(),
                 email = email,
                 password = passwordEncoder.encode(password),
                 nickname = nickname,
-            ).apply { id = idGenerator.generate() }
+            )
 
         val saved = userRepository.save(user)
         return RegisterUserResponse.from(saved)

--- a/modules/user/src/main/kotlin/com/nextmall/user/domain/model/User.kt
+++ b/modules/user/src/main/kotlin/com/nextmall/user/domain/model/User.kt
@@ -5,11 +5,15 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
 import jakarta.persistence.Table
 
 @Entity
 @Table(name = "users")
 class User(
+    @Id
+    val id: Long,
+
     @Column(nullable = false, unique = true)
     val email: String,
 

--- a/modules/user/src/test/kotlin/com/nextmall/user/application/usecase/FindUserUseCaseTest.kt
+++ b/modules/user/src/test/kotlin/com/nextmall/user/application/usecase/FindUserUseCaseTest.kt
@@ -23,10 +23,11 @@ class FindUserUseCaseTest :
             // given
             val user =
                 User(
+                    id = 1L,
                     email = "test@a.com",
                     password = "pw",
                     nickname = "tester",
-                ).apply { id = 1L }
+                )
 
             val response =
                 UserResponse(

--- a/modules/user/src/test/kotlin/com/nextmall/user/application/usecase/RegisterUserUseCaseTest.kt
+++ b/modules/user/src/test/kotlin/com/nextmall/user/application/usecase/RegisterUserUseCaseTest.kt
@@ -18,7 +18,12 @@ class RegisterUserUseCaseTest :
         val userRepository = mockk<UserRepository>()
         val passwordEncoder = mockk<PasswordEncoder>()
         val idGenerator = mockk<IdGenerator>()
-        val useCase = RegisterUserUseCase(userRepository, passwordEncoder, idGenerator)
+
+        lateinit var useCase: RegisterUserUseCase
+
+        beforeTest {
+            useCase = RegisterUserUseCase(userRepository, passwordEncoder, idGenerator)
+        }
 
         test("정상 회원가입 시 ID 생성, 비밀번호 암호화, 저장이 정상적으로 이루어진다") {
             // given

--- a/modules/user/src/test/kotlin/com/nextmall/user/domain/repository/UserRepositoryIdTest.kt
+++ b/modules/user/src/test/kotlin/com/nextmall/user/domain/repository/UserRepositoryIdTest.kt
@@ -19,16 +19,15 @@ class UserRepositoryIdTest(
             val generatedId = idGenerator.generate()
             val user =
                 User(
+                    id = generatedId,
                     email = "snow@id.com",
                     password = "encoded",
                     nickname = "snowflake",
-                ).apply {
-                    id = generatedId
-                }
+                )
 
             // when
             val saved = userRepository.save(user)
-            val found = userRepository.findById(saved.id!!)
+            val found = userRepository.findById(saved.id)
 
             // then
             found.shouldNotBeNull()
@@ -44,17 +43,19 @@ class UserRepositoryIdTest(
 
             val user1 =
                 User(
+                    id = id1,
                     email = "test1@test.com",
                     password = "encoded",
                     nickname = "user1",
-                ).apply { id = id1 }
+                )
 
             val user2 =
                 User(
+                    id = id2,
                     email = "test2@test.com",
                     password = "encoded",
                     nickname = "user2",
-                ).apply { id = id2 }
+                )
 
             // when
             val saved1 = userRepository.save(user1)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,8 +8,9 @@ include("modules:auth") // 인증/인가 도메인 (Authentication & Authorizati
 include("modules:user") // 회원 도메인 (User Registration, Profile, Role 등)
 
 // ──────────────── Common Infrastructure ────────────────
-include("common:security") // 공통 보안/암호화/비밀번호 해시 관리
-include("common:data") // 데이터 접근 계층 (JPA, Redis, Kafka, JOOQ 등 통합 설정)
-include("common:util") // 범용 유틸리티 (시간, 문자열, JSON, Validation 등)
+include("common:security") // 공통 보안/암호화/비밀번호 해시
+include("common:data") // 데이터 코어(JPA, jOOQ 등 공통 설정)
+include("common:redis") // Redis 공통 인프라 설정
+include("common:util") // 범용 유틸리티(시간, 문자열, JSON 등)
 include("common:identifier") // 식별자 생성/관리
-include("common:test-support") // 테스트 공통 환경 및 유틸 (Kotest, Mock, Fixture 등)
+include("common:test-support") // 테스트 공통 환경 및 유틸


### PR DESCRIPTION
## 🧾 Summary of Changes
- common:redis 모듈 추가 및 RedisOperator 구현
- RateLimitRepository 도입 (실패 카운트 증가/조회/초기화)
- LoginUseCase를 credential 기반 RateLimit 구조로 리팩토링
- TooManyLoginAttemptsException, InvalidLoginException 적용
- BaseEntity에서 id 필드를 제거하고 각 엔티티에서 개별 관리하도록 구조 개선
- User 엔티티 id를 val로 전환하여 불변성 강화
- 인증 전체 테스트 재정비 (mock 격리, verify 검증 추가)
- 회원가입 및 로그인 흐름의 도메인 규칙 정리 및 코드 개선

---

## 🔗 Related Issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 보안 강화: 5회 연속 실패 시 5분간 계정 접근 제한

* **개선 사항**
  * 로그인 실패 시 명확한 오류 메시지 제공
  * Redis 통합으로 시스템 성능 및 확장성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->