### PR TITLE
fix(auth): 로그인 시 Refresh Token 저장 로직 누락 수정 및 전체 인증 흐름 안정화

### DIFF
--- a/modules/auth/src/main/kotlin/com/nextmall/auth/application/usecase/LogoutUseCase.kt
+++ b/modules/auth/src/main/kotlin/com/nextmall/auth/application/usecase/LogoutUseCase.kt
@@ -10,7 +10,9 @@ class LogoutUseCase(
     private val refreshTokenStore: RefreshTokenStore,
 ) {
     fun logout(refreshToken: String) {
-        val userId = tokenProvider.parseRefreshToken(refreshToken)
-        refreshTokenStore.delete(userId)
+        runCatching {
+            val userId = tokenProvider.parseRefreshToken(refreshToken)
+            refreshTokenStore.delete(userId)
+        }
     }
 }

--- a/modules/auth/src/main/kotlin/com/nextmall/auth/application/usecase/LogoutUseCase.kt
+++ b/modules/auth/src/main/kotlin/com/nextmall/auth/application/usecase/LogoutUseCase.kt
@@ -1,0 +1,16 @@
+package com.nextmall.auth.application.usecase
+
+import com.nextmall.auth.domain.jwt.TokenProvider
+import com.nextmall.auth.domain.refresh.RefreshTokenStore
+import org.springframework.stereotype.Service
+
+@Service
+class LogoutUseCase(
+    private val tokenProvider: TokenProvider,
+    private val refreshTokenStore: RefreshTokenStore,
+) {
+    fun logout(refreshToken: String) {
+        val userId = tokenProvider.parseRefreshToken(refreshToken)
+        refreshTokenStore.delete(userId)
+    }
+}

--- a/modules/auth/src/main/kotlin/com/nextmall/auth/application/usecase/LogoutUseCase.kt
+++ b/modules/auth/src/main/kotlin/com/nextmall/auth/application/usecase/LogoutUseCase.kt
@@ -2,6 +2,7 @@ package com.nextmall.auth.application.usecase
 
 import com.nextmall.auth.domain.jwt.TokenProvider
 import com.nextmall.auth.domain.refresh.RefreshTokenStore
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -9,10 +10,15 @@ class LogoutUseCase(
     private val tokenProvider: TokenProvider,
     private val refreshTokenStore: RefreshTokenStore,
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     fun logout(refreshToken: String) {
         runCatching {
             val userId = tokenProvider.parseRefreshToken(refreshToken)
             refreshTokenStore.delete(userId)
+            logger.debug("Logout completed: userId={}", userId)
+        }.onFailure { e ->
+            logger.info("Logout operation failed (gracefully handled): ${e.message}")
         }
     }
 }

--- a/modules/auth/src/main/kotlin/com/nextmall/auth/presentation/controller/AuthController.kt
+++ b/modules/auth/src/main/kotlin/com/nextmall/auth/presentation/controller/AuthController.kt
@@ -1,6 +1,7 @@
 package com.nextmall.auth.presentation.controller
 
 import com.nextmall.auth.application.usecase.LoginUseCase
+import com.nextmall.auth.application.usecase.LogoutUseCase
 import com.nextmall.auth.application.usecase.RefreshTokenUseCase
 import com.nextmall.auth.presentation.dto.LoginRequest
 import com.nextmall.auth.presentation.dto.RefreshTokenRequest
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val loginUseCase: LoginUseCase,
     private val refreshTokenUseCase: RefreshTokenUseCase,
+    private val logoutUseCase: LogoutUseCase,
 ) {
     @PostMapping("/login")
     fun login(
@@ -40,5 +42,16 @@ class AuthController(
 
         return ResponseEntity
             .ok(response)
+    }
+
+    @PostMapping("/logout")
+    fun logout(
+        @Valid @RequestBody request: RefreshTokenRequest,
+    ): ResponseEntity<Unit> {
+        logoutUseCase.logout(request.refreshToken)
+
+        return ResponseEntity
+            .ok()
+            .build()
     }
 }

--- a/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LoginUseCaseTest.kt
+++ b/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LoginUseCaseTest.kt
@@ -32,7 +32,7 @@ class LoginUseCaseTest :
         lateinit var userCase: LoginUseCase
 
         beforeTest {
-            clearMocks(userRepository, passwordEncoder, tokenProvider, rateLimitRepository)
+            clearMocks(userRepository, passwordEncoder, tokenProvider, rateLimitRepository, refreshTokenStore)
             userCase =
                 LoginUseCase(
                     userRepository = userRepository,

--- a/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LoginUseCaseTest.kt
+++ b/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LoginUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.nextmall.auth.domain.exception.InvalidLoginException
 import com.nextmall.auth.domain.exception.TooManyLoginAttemptsException
 import com.nextmall.auth.domain.jwt.TokenProvider
 import com.nextmall.auth.domain.model.LoginIdentity
+import com.nextmall.auth.domain.refresh.RefreshTokenStore
 import com.nextmall.auth.infrastructure.redis.RateLimitRepository
 import com.nextmall.user.domain.model.AuthProvider
 import com.nextmall.user.domain.model.User
@@ -26,6 +27,7 @@ class LoginUseCaseTest :
         val passwordEncoder = mockk<PasswordEncoder>()
         val tokenProvider = mockk<TokenProvider>()
         val rateLimitRepository = mockk<RateLimitRepository>()
+        val refreshTokenStore = mockk<RefreshTokenStore>()
 
         lateinit var userCase: LoginUseCase
 
@@ -37,17 +39,20 @@ class LoginUseCaseTest :
                     passwordEncoder = passwordEncoder,
                     tokenProvider = tokenProvider,
                     rateLimitRepository = rateLimitRepository,
+                    refreshTokenStore = refreshTokenStore,
                 )
         }
 
-        test("정상 로그인 시 토큰 두 개가 발급된다") {
+        test("정상 로그인 시 토큰 두 개가 발급되고 RefreshToken이 저장된다") {
             // given
             val user = User(id = 1L, email = "test@a.com", password = "encoded", nickname = "tester")
 
             every { userRepository.findByEmail("test@a.com") } returns user
             every { passwordEncoder.matches("plain", "encoded") } returns true
-            every { tokenProvider.generateAccessToken(any()) } returns "access"
-            every { tokenProvider.generateRefreshToken(any()) } returns "refresh"
+            every { tokenProvider.generateAccessToken("1") } returns "access"
+            every { tokenProvider.generateRefreshToken("1") } returns "refresh"
+            every { tokenProvider.refreshTokenTtlSeconds() } returns 3600
+            every { refreshTokenStore.save(1L, "refresh", 3600) } just Runs
             every { rateLimitRepository.resetFailCount(any()) } just Runs
             every { rateLimitRepository.getFailCount(any()) } returns 0
 
@@ -60,6 +65,7 @@ class LoginUseCaseTest :
 
             verify(exactly = 1) {
                 rateLimitRepository.resetFailCount(any())
+                refreshTokenStore.save(1L, "refresh", 3600)
             }
         }
 

--- a/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LogoutUseCaseTest.kt
+++ b/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LogoutUseCaseTest.kt
@@ -29,4 +29,10 @@ class LogoutUseCaseTest :
 
             verify(exactly = 1) { store.delete(1L) }
         }
+
+        test("유효하지 않은 refresh token이어도 로그아웃은 예외를 던지지 않는다") {
+            every { tokenProvider.parseRefreshToken("invalid-rt") } throws IllegalArgumentException("Invalid token")
+
+            useCase.logout("invalid-rt")
+        }
     })

--- a/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LogoutUseCaseTest.kt
+++ b/modules/auth/src/test/kotlin/com/nextmall/auth/application/usecase/LogoutUseCaseTest.kt
@@ -1,0 +1,32 @@
+package com.nextmall.auth.application.usecase
+
+import com.nextmall.auth.domain.jwt.TokenProvider
+import com.nextmall.auth.domain.refresh.RefreshTokenStore
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class LogoutUseCaseTest :
+    FunSpec({
+
+        val tokenProvider = mockk<TokenProvider>()
+        val store = mockk<RefreshTokenStore>()
+
+        lateinit var useCase: LogoutUseCase
+
+        beforeTest {
+            clearMocks(tokenProvider, store)
+            useCase = LogoutUseCase(tokenProvider, store)
+        }
+
+        test("로그아웃 시 refresh token이 삭제된다") {
+            every { tokenProvider.parseRefreshToken("rt") } returns 1L
+            every { store.delete(1L) } returns true
+
+            useCase.logout("rt")
+
+            verify(exactly = 1) { store.delete(1L) }
+        }
+    })

--- a/modules/auth/src/test/kotlin/com/nextmall/auth/presentation/controller/AuthControllerTest.kt
+++ b/modules/auth/src/test/kotlin/com/nextmall/auth/presentation/controller/AuthControllerTest.kt
@@ -2,6 +2,7 @@ package com.nextmall.auth.presentation.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.nextmall.auth.application.usecase.LoginUseCase
+import com.nextmall.auth.application.usecase.LogoutUseCase
 import com.nextmall.auth.application.usecase.RefreshTokenUseCase
 import com.nextmall.auth.presentation.dto.LoginRequest
 import com.nextmall.auth.presentation.dto.RefreshTokenRequest
@@ -22,6 +23,8 @@ class AuthControllerTest(
     private val loginUseCase: LoginUseCase,
     @MockkBean
     private val refreshTokenUseCase: RefreshTokenUseCase,
+    @MockkBean
+    private val logoutUseCase: LogoutUseCase,
 ) : FunSpec({
 
         test("로그인 요청이 성공하면 토큰이 반환된다") {
@@ -84,6 +87,20 @@ class AuthControllerTest(
                     jsonPath("$.refreshToken") {
                         value("new-refresh")
                     }
+                }
+        }
+
+        test("로그아웃 성공 시 200을 반환한다") {
+            val req = RefreshTokenRequest("old-rt")
+
+            every { logoutUseCase.logout("old-rt") } returns Unit
+
+            mockMvc
+                .post("/api/v1/auth/logout") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(req)
+                }.andExpect {
+                    status { isOk() }
                 }
         }
     })


### PR DESCRIPTION
## Summary of Changes
- LoginUseCase에 refreshTokenStore.save 추가하여 Refresh Token 회수 문제 해결
- 로그인/리프레시/로그아웃 흐름 전체 재점검 및 정상 동작 검증
- Refresh Token 기반 인증 로테이션 구조 보완


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그아웃 기능 추가 및 /api/v1/auth/logout 엔드포인트 제공

* **개선**
  * 로그인 시 리프레시 토큰을 생성 후 서버에 저장하도록 변경 — 토큰 발급 및 TTL 관리 강화

* **테스트**
  * 로그인/로그아웃 흐름 관련 단위 및 컨트롤러 테스트 추가·갱신 — 저장/삭제 동작과 에러 처리 검증 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->